### PR TITLE
Fix resolve MVP ambiguity

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   - [Symphony WFM](#symphony-wfm)
   - [Repositories and Registry](#repositories-and-registry)
   - [Telemetry and Monitoring](#telemetry-and-monitoring)
-  - [MVP Pattern](#mvp-pattern)
+  - [HB-MVP Pattern](#hb-mvp-pattern)
 - [HTTP/1.1 and API Security](#http11-and-api-security)
 - [Release Notes](#release-notes)
 - [Comments and Feedback](#comments-and-feedback)
@@ -132,8 +132,8 @@ This includes the following elements -
 - Jaeger is deployed for tracing.
 - Prometheus is deployed for Metrics collection.
 
-#### MVP Pattern
-Eclipse Symphony is an open-source orchestration platform developed by the Eclipse Foundation to unify and manage complex workloads across diverse systems. In the context of Eclipse Symphony, MVP refers to a design pattern for building extensible systems, specifically a three-tiered architecture consisting of Managers, Vendors, and Providers.
+#### HB-MVP Pattern
+Eclipse Symphony is an open-source orchestration platform developed by the Eclipse Foundation to unify and manage complex workloads across diverse systems. In the context of Eclipse Symphony, HB-MVP refers to a design pattern for building extensible systems, specifically a three-tiered architecture consisting of Managers, Vendors, and Providers.
 
 This pattern is often referred to as HB-MVP (Host-Bound MVP):
 
@@ -146,7 +146,7 @@ This pattern is often referred to as HB-MVP (Host-Bound MVP):
 - **Managers**: Managers implement the platform-agnostic business logic for a given capability. They receive requests from vendors and orchestrate the necessary actions, often by interacting with one or more providers. Managers are designed for reuse and encapsulate the core business logic.
 - **Providers**: Providers are responsible for interacting with specific external systems or dependencies. They abstract away the details of platform-specific interactions, containing any platform-specific knowledge within their scope. Managers utilize providers to perform actions on external resources.
 
-Code First Sandbox uses MVP pattern to implement Margo specification.
+Code First Sandbox uses HB-MVP pattern to implement Margo specification.
 
 ---
 


### PR DESCRIPTION
The 3-letter acronym MVP is rather known as Model-View-Presenter pattern, Most-Valuable-Player or Minimal-Viable-Product. Here it is used with a completely different and rather unknown meaning. Since the only found reference in the internet calls it `HB-MVP`, this patch used the same naming to resolve the ambiguity.