### PR TITLE
fix: failure when installing docker-compose-plugin

### DIFF
--- a/.github/workflows/sandbox-sanity-test.yml
+++ b/.github/workflows/sandbox-sanity-test.yml
@@ -65,14 +65,6 @@ jobs:
           (
             sudo apt-get update
             sudo apt-get install -y curl jq openssl git
-            sudo install -m 0755 -d /etc/apt/keyrings
-            sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
-            sudo chmod a+r /etc/apt/keyrings/docker.asc
-            echo \
-              "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
-              $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
-              sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
-            sudo apt-get update
           ) &
 
           (

--- a/scripts/modules/docker.sh
+++ b/scripts/modules/docker.sh
@@ -32,8 +32,6 @@ install_docker_and_compose() {
       "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
       ${UBUNTU_CODENAME} stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
 
-    DOCKER_KEYRINGS_INSTALLED=true
-
     sudo apt-get update
     sudo apt-get install -y \
       docker-ce=5:${DOCKER_VERSION}-1~ubuntu.24.04~${UBUNTU_CODENAME} \
@@ -56,16 +54,6 @@ install_docker_and_compose() {
     CURRENT_COMPOSE_VERSION=$(docker compose version --short 2>/dev/null | sed 's/v//')
     echo "⚡️ Docker Compose ${CURRENT_COMPOSE_VERSION} already installed"
   else
-    if [ "${DOCKER_KEYRINGS_INSTALLED}" != "true" ]; then
-      sudo install -m 0755 -d /etc/apt/keyrings
-      sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
-      sudo chmod a+r /etc/apt/keyrings/docker.asc
-
-      echo \
-        "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
-        ${UBUNTU_CODENAME} stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
-    fi
-
     sudo apt-get update
     sudo apt-get install -y docker-compose-plugin=${DOCKER_COMPOSE_VERSION}-1~ubuntu.24.04~${UBUNTU_CODENAME}
   fi

--- a/scripts/modules/docker.sh
+++ b/scripts/modules/docker.sh
@@ -32,6 +32,8 @@ install_docker_and_compose() {
       "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
       ${UBUNTU_CODENAME} stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
 
+    DOCKER_KEYRINGS_INSTALLED=true
+
     sudo apt-get update
     sudo apt-get install -y \
       docker-ce=5:${DOCKER_VERSION}-1~ubuntu.24.04~${UBUNTU_CODENAME} \
@@ -54,6 +56,16 @@ install_docker_and_compose() {
     CURRENT_COMPOSE_VERSION=$(docker compose version --short 2>/dev/null | sed 's/v//')
     echo "⚡️ Docker Compose ${CURRENT_COMPOSE_VERSION} already installed"
   else
+    if [ "${DOCKER_KEYRINGS_INSTALLED}" != "true" ]; then
+      sudo install -m 0755 -d /etc/apt/keyrings
+      sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+      sudo chmod a+r /etc/apt/keyrings/docker.asc
+
+      echo \
+        "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
+        ${UBUNTU_CODENAME} stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+    fi
+
     sudo apt-get update
     sudo apt-get install -y docker-compose-plugin=${DOCKER_COMPOSE_VERSION}-1~ubuntu.24.04~${UBUNTU_CODENAME}
   fi


### PR DESCRIPTION
* fix: reproduce [the installation issue](https://github.com/margo/sandbox/actions/runs/28874082245/job/85644314361?pr=339
) for TDD
```
Reading package lists...
Reading package lists...
Building dependency tree...
Reading state information...
Package docker-compose-plugin is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source

E: Version '5.0.0-1~ubuntu.24.04~noble' for 'docker-compose-plugin' was not found
Error: Process completed with exit code 100.
```
* fix: add condition for DOCKER_KEYRINGS_INSTALLED

Close: #336 