### PR TITLE
fix(prerequisites): clean up residual artifacts during prerequisite reinstallation/uninstallation

### DIFF
--- a/scripts/modules/harbor.sh
+++ b/scripts/modules/harbor.sh
@@ -284,10 +284,9 @@ configure_harbor_trust_for_k3s() {
   PORT="${EXPOSED_HARBOR_PORT}"
   CERT_DIR="/var/lib/rancher/k3s/agent/etc/containerd/certs.d/${HOST}:${PORT}"
 
-  if [ -f "$CERT_DIR/ca.crt" ] && [ -f "$CERT_DIR/hosts.toml" ]; then
-    echo "✅ Harbor trust already present — skipping k3s restart"
-    return 0
-  fi
+  sudo rm -f "$CERT_DIR/ca.crt"
+  sudo rm -f "$CERT_DIR/hosts.toml"
+
   # Check if harbor certificates are present or not, in HOME_CERT_DIR 
   if [ ! -f "$HOME_HARBOR_CERT" ]; then
       echo "Harbor Certificates (from WFM) not found at $HOME/certs, cannot proceed."

--- a/scripts/wfm.sh
+++ b/scripts/wfm.sh
@@ -290,8 +290,26 @@ cleanup_basic_utilities() {
   echo "⚠️ Basic utilities (curl) left installed as they may be system dependencies"
 
   echo "✅ Environment cleanup completed"
+
+  cleanup_docker_resources
+
   echo ""
   echo "🔄 Please restart your shell or run 'source ~/.bashrc' to apply PATH changes"
+}
+
+cleanup_docker_resources() {
+    if ! command -v docker >/dev/null 2>&1; then
+        echo "Docker is not installed. Skipping cleanup."
+        return 0
+    fi
+
+    echo "Removing exited containers..."
+    docker container prune -f >/dev/null 2>&1
+
+    echo "Removing unused volumes..."
+    docker volume prune -f >/dev/null 2>&1
+
+    echo "Docker cleanup completed."
 }
 
 


### PR DESCRIPTION
## Conventional Changes

- fix: override Harbor certificates in k3s during prerequisite installation
- fix: remove exited Docker containers and dangling volumes during prerequisite uninstallation

## Why

Fixes reinstallation issues caused by residual artifacts from previous installations (e.g., stale Harbor certificates, exited containers, and dangling Docker volumes) that could interfere with newly installed prerequisites.