### PR TITLE
feat(scripts): add arm64 support for Go and Helm on standalone devices; Oras on WFM

### DIFF
--- a/.github/workflows/lint-commit.yml
+++ b/.github/workflows/lint-commit.yml
@@ -7,7 +7,7 @@ permissions:
 
 jobs:
   lint-commit:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   lint-yaml:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v6
       - uses: ibiqlik/action-yamllint@v2
@@ -30,7 +30,7 @@ jobs:
 
 
   lint-go:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
@@ -41,7 +41,7 @@ jobs:
           version: v2.11
 
   lint-container-manifests:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v6
       - name: Install Helm
@@ -53,7 +53,7 @@ jobs:
           docker compose -f docker-compose/docker-compose.yaml config > /dev/null
 
   test-go:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   release:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/sandbox-sanity-test.yml
+++ b/.github/workflows/sandbox-sanity-test.yml
@@ -27,7 +27,7 @@ permissions:
 
 jobs:
   sandbox-e2e-functional-test-job:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-arm
     env:
       CI: "true"
       # Branches

--- a/scripts/device-agent.sh
+++ b/scripts/device-agent.sh
@@ -154,7 +154,6 @@ install_basic_utilities() {
   if [ "$DEVICE_TYPE" = "k3s" ]; then
     INSTALL_HELM_V3_15_1=true
     HELM_VERSION="3.15.1"
-    HELM_TAR="helm-v${HELM_VERSION}-linux-amd64.tar.gz"
     HELM_BIN_DIR="/usr/local/bin"
     install_helm
     echo "✅ Helm installed for k3s device"

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -25,3 +25,19 @@ package_installed() {
 get_ubuntu_codename() {
     lsb_release -cs 2>/dev/null || echo "noble"
 }
+
+resolve_target_arch() {
+    local host_arch="$(uname -m)"
+    case "${host_arch}" in
+        x86_64|amd64)
+            echo "amd64"
+            ;;
+        aarch64|arm64)
+            echo "arm64"
+            ;;
+        *)
+            echo "Unsupported architecture" >&2
+            return 1
+            ;;
+    esac
+}

--- a/scripts/modules/go.sh
+++ b/scripts/modules/go.sh
@@ -7,6 +7,9 @@ source "$(dirname "${BASH_SOURCE[0]}")/../lib/common.sh"
 install_go() {
   cd $HOME
   echo "🔄 Installing Go..."
+  local CPU_ARCH
+  CPU_ARCH="$(resolve_target_arch)" || return 1
+
   if [[ "$PATH" != *"/usr/local/go/bin"* ]] ; then
     export PATH=$PATH:/usr/local/go/bin
   fi
@@ -16,7 +19,7 @@ install_go() {
     echo "⚡️ Go ${GO_VERSION} already installed, skipping installation"
   else
     sudo rm -rf /usr/local/go /usr/bin/go
-    wget "https://go.dev/dl/go1.25.10.linux-amd64.tar.gz" -O go.tar.gz
+    wget "https://go.dev/dl/go1.25.10.linux-${CPU_ARCH}.tar.gz" -O go.tar.gz
     sudo tar -C /usr/local -xzf go.tar.gz
     rm go.tar.gz
     which go

--- a/scripts/modules/helm.sh
+++ b/scripts/modules/helm.sh
@@ -6,8 +6,13 @@ source "$(dirname "${BASH_SOURCE[0]}")/../lib/common.sh"
 install_helm() {
   cd $HOME
   local HELM_VERSION="3.15.1"
-  local HELM_TAR="helm-v${HELM_VERSION}-linux-amd64.tar.gz"
+  local CPU_ARCH
   local HELM_BIN_DIR="/usr/local/bin"
+  local HELM_TAR
+
+  CPU_ARCH="$(resolve_target_arch)" || return 1
+
+  HELM_TAR="helm-v${HELM_VERSION}-linux-${CPU_ARCH}.tar.gz"
 
   echo "🔄 Installing Helm..."
   if command_exists helm && [[ "$(helm version --short | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')" == "${HELM_VERSION}" ]]; then
@@ -16,9 +21,9 @@ install_helm() {
       echo "Downloading Helm version ${HELM_VERSION}..."
       wget -q "https://get.helm.sh/${HELM_TAR}" || { echo "Failed to download Helm."; exit 1; }
       tar -xzf "${HELM_TAR}" || { echo "Failed to extract Helm."; exit 1; }
-      sudo mv "linux-amd64/helm" "${HELM_BIN_DIR}/" || { echo "Failed to move Helm."; exit 1; }
+      sudo mv "linux-${CPU_ARCH}/helm" "${HELM_BIN_DIR}/" || { echo "Failed to move Helm."; exit 1; }
       rm "${HELM_TAR}"
-      rm -rf linux-amd64/
+      rm -rf "linux-${CPU_ARCH}/"
       echo '✅ Helm installed'
   fi
 }

--- a/scripts/modules/oras.sh
+++ b/scripts/modules/oras.sh
@@ -14,10 +14,14 @@ install_oras() {
 
   cd /tmp
   local ORAS_VERSION="1.1.0"
-  wget "https://github.com/oras-project/oras/releases/download/v${ORAS_VERSION}/oras_${ORAS_VERSION}_linux_amd64.tar.gz"
-  tar -xzf "oras_${ORAS_VERSION}_linux_amd64.tar.gz"
+  local ORAS_ARCH
+  ORAS_ARCH="$(resolve_target_arch)" || return 1
+  local ORAS_TARBALL="oras_${ORAS_VERSION}_linux_${ORAS_ARCH}.tar.gz"
+
+  wget "https://github.com/oras-project/oras/releases/download/v${ORAS_VERSION}/${ORAS_TARBALL}"
+  tar -xzf "${ORAS_TARBALL}"
   sudo mv oras /usr/local/bin/
-  rm "oras_${ORAS_VERSION}_linux_amd64.tar.gz"
+  rm "${ORAS_TARBALL}"
 
   ORAS_VERSION="$(oras version | head -n 1 | cut -d ':' -f 2 | sed 's/[[:space:]]*//')"
   echo "✅ ORAS ${ORAS_VERSION} installed"


### PR DESCRIPTION
## Description
Update Oras, Go and Helm module scripts to be architecture-aware for standalone devices and WFM instead of hardcoding amd64.

## Testing
Move CI and release workflows to ARM runners temporary for testing the 1st commit of PR