### PR TITLE
fix(device-agent): removes redundant db update while setting desired state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .buildx-cache/
+vendor

--- a/poc/device/agent/database/database.go
+++ b/poc/device/agent/database/database.go
@@ -301,6 +301,7 @@ func (db *Database) SetDesiredState(deploymentId string, state AppDeploymentStat
 
 	record, exists := db.deployments[deploymentId]
 	if !exists {
+		// initialise a record object
 		record = &DeploymentRecord{
 			AppID:               deploymentId,
 			DeploymentID:        deploymentId,
@@ -308,8 +309,7 @@ func (db *Database) SetDesiredState(deploymentId string, state AppDeploymentStat
 			Phase:               "pending",
 			LastUpdated:         time.Now(),
 		}
-		db.deployments[deploymentId] = record
-		db.notify(deploymentId, record, DeploymentChangeTypeDesiredStateAdded)
+		// db.notify(deploymentId, record, DeploymentChangeTypeDesiredStateAdded)
 	}
 
 	// Only update if actually different
@@ -324,6 +324,8 @@ func (db *Database) SetDesiredState(deploymentId string, state AppDeploymentStat
 	if state.URL != nil {
 		record.URL = *state.URL
 	}
+	// record should be updated in db after assigning all fields in record
+	db.deployments[deploymentId] = record
 
 	db.notify(deploymentId, record, DeploymentChangeTypeDesiredStateAdded)
 

--- a/poc/device/agent/database/database.go
+++ b/poc/device/agent/database/database.go
@@ -297,6 +297,8 @@ func (db *Database) notify(
 
 func (db *Database) SetDesiredState(deploymentId string, state AppDeploymentState) error {
 	db.mu.Lock()
+
+	defer db.TriggerDataPersist()
 	defer db.mu.Unlock()
 
 	record, exists := db.deployments[deploymentId]
@@ -309,12 +311,8 @@ func (db *Database) SetDesiredState(deploymentId string, state AppDeploymentStat
 			Phase:               "pending",
 			LastUpdated:         time.Now(),
 		}
-		// db.notify(deploymentId, record, DeploymentChangeTypeDesiredStateAdded)
 	}
 
-	// Only update if actually different
-	// if record.DesiredState == nil || record.DesiredState.AppDeploymentYAMLHash !=
-	// state.AppDeploymentYAMLHash {
 	record.DesiredState = &state
 	record.LastUpdated = time.Now()
 	// Store the digest and URL from the state
@@ -328,8 +326,6 @@ func (db *Database) SetDesiredState(deploymentId string, state AppDeploymentStat
 	db.deployments[deploymentId] = record
 
 	db.notify(deploymentId, record, DeploymentChangeTypeDesiredStateAdded)
-
-	db.TriggerDataPersist()
 
 	return nil
 }


### PR DESCRIPTION
Fixes a minor bug where database is notified multiple times where single notification was required. Initial notification essentially does nothing. 