### PR TITLE
Added label support in WFM Client

### DIFF
--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -196,6 +196,16 @@ On each VM, you need to configure environment variables (settings that tell the 
    ```bash
    cd $HOME/workspace/sandbox/scripts
    ```
+3. **(Optional) Generate Labels for Device**
+
+   If you want device to inherit user-defined labels, first create the required labels using the provided helper script.
+
+   Run:
+
+   ```bash
+   bash create-device-labels.sh
+   ```
+   and follow on screen instructions to create user defined labels. Prefixing with an organization domain is RECOMMENDED for supplier-specific labels.
 
 3. **Install Basic Tools**
 

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -207,6 +207,23 @@ On each VM, you need to configure environment variables (settings that tell the 
    ```
    and follow on screen instructions to create user defined labels. Prefixing with an organization domain is RECOMMENDED for supplier-specific labels.
 
+   Alternatively, if you have labels prepared & just want to use them without using above helper script, you can:
+   - Create a labels.json file in current working directory
+   - Paste your labels as a json object in labels.json, finally file should look like this: 
+      ```json
+      {
+        "northstarida.com/hypervisor": "hyper-v",
+        "northstarida.com/wasm.runtime": [
+            "wamr"
+        ],
+        "northstarida.com/wasm.package.format": [
+            ".wasm",
+            ".aot"
+        ],
+        "northstarida.com/os": "zephyr"
+      }
+      ```
+
 3. **Install Basic Tools**
 
    Based on the device type, select **k3s** or **docker** while sourcing the environment variables. For example:

--- a/poc/device/agent/config/capabilities.json
+++ b/poc/device/agent/config/capabilities.json
@@ -1,6 +1,17 @@
 {
     "apiVersion": "device.margo.org/v1alpha1",
     "kind": "DeviceCapabilitiesManifest",
+    "labels": {
+        "northstarida.com/hypervisor": "hyper-v",
+        "northstarida.com/wasm.runtime": [
+            "wamr"
+        ],
+        "northstarida.com/wasm.package.format": [
+            ".wasm",
+            ".aot"
+        ],
+        "northstarida.com/os": "zephyr"
+    },
     "properties": {
         "id": "northstarida.xtapro.k8s.edge",
         "vendor": "Northstar Industrial Devices",

--- a/poc/device/agent/onboarding.go
+++ b/poc/device/agent/onboarding.go
@@ -47,7 +47,7 @@ func WithEnableHelmDeployment() Option {
 
 		auth.supportedRuntimes = append(
 			auth.supportedRuntimes,
-			sbi.Oci,
+			sbi.DeviceCapabilitiesManifestPropertiesSupportedRuntimesOci,
 		)
 	}
 }

--- a/poc/device/agent/onboarding.go
+++ b/poc/device/agent/onboarding.go
@@ -14,8 +14,7 @@ import (
 )
 
 type DeviceClientSettings struct {
-	deviceClientId string
-
+	deviceClientId                                  string
 	deviceRootIdentity                              types.DeviceRootIdentity
 	authEnabled                                     bool
 	wfmEndpointsForClient                           []string

--- a/poc/device/agent/types/config_test.go
+++ b/poc/device/agent/types/config_test.go
@@ -1,0 +1,18 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestThatConfigIsLoadedFromDisk(t *testing.T) {
+
+	manifest, err := LoadCapabilities("../config/capabilities.json")
+	assert.Nil(t, err, "error should be nil")
+	assert.NotNil(t, manifest.Labels)
+	k := *manifest.Labels
+	str, err := k["northstarida.com/hypervisor"].AsDeviceCapabilitiesManifestLabels0()
+	assert.Nil(t, err, "error should be nil")
+	assert.Equal(t, "hyper-v", str, "hypervisor value should be equal")
+}

--- a/scripts/create-device-labels.sh
+++ b/scripts/create-device-labels.sh
@@ -1,0 +1,268 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+OUTPUT_FILE="labels.json"
+
+print_header() {
+    echo
+    echo "========================================"
+    echo "        Labels JSON Builder"
+    echo "========================================"
+    echo "Output file: $OUTPUT_FILE"
+    echo
+}
+
+initialize_json_file() {
+    if [[ ! -f "$OUTPUT_FILE" || ! -s "$OUTPUT_FILE" ]]; then
+        echo "{}" > "$OUTPUT_FILE"
+        return
+    fi
+
+    if ! python3 -m json.tool "$OUTPUT_FILE" > /dev/null 2>&1; then
+        echo "Warning: $OUTPUT_FILE exists but is not valid JSON."
+        read -rp "Do you want to overwrite it with an empty JSON object? [y/N]: " overwrite
+        case "$overwrite" in
+            y|Y|yes|YES)
+                echo "{}" > "$OUTPUT_FILE"
+                ;;
+            *)
+                echo "Cannot continue with invalid JSON. Exiting."
+                exit 1
+                ;;
+        esac
+    fi
+}
+
+show_main_menu() {
+    echo
+    echo "What would you like to do?"
+    echo "1) Add a new key-value pair"
+    echo "2) View current labels.json"
+    echo "3) Exit"
+    echo
+}
+
+show_value_types() {
+    echo
+    echo "Select the value type:"
+    echo "1) String"
+    echo "2) Number"
+    echo "3) Boolean"
+    echo "4) Array of strings"
+    echo "5) Array of numbers"
+    echo
+}
+
+validate_number() {
+    local value="$1"
+    [[ "$value" =~ ^-?([0-9]+)([.][0-9]+)?$ ]]
+}
+
+validate_boolean() {
+    local value="$1"
+    [[ "$value" == "true" || "$value" == "false" ]]
+}
+
+warn_if_no_domain_prefix() {
+    local key="$1"
+
+    if [[ ! "$key" =~ ^[A-Za-z0-9.-]+/[^/]+$ ]]; then
+        echo
+        echo "Note: Prefixing with an organization domain is recommended for supplier-specific labels."
+        echo "Example: example.com/$key"
+        echo
+    fi
+}
+
+read_non_empty() {
+    local prompt="$1"
+    local input=""
+
+    while true; do
+        read -rp "$prompt" input
+        if [[ -n "$input" ]]; then
+            printf '%s' "$input"
+            return 0
+        fi
+        echo "Input cannot be empty. Please try again."
+    done
+}
+
+add_to_json() {
+    local key="$1"
+    local type="$2"
+    local value="$3"
+
+    python3 - "$OUTPUT_FILE" "$key" "$type" "$value" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+file_path = Path(sys.argv[1])
+key = sys.argv[2]
+value_type = sys.argv[3]
+raw_value = sys.argv[4]
+
+try:
+    with file_path.open("r", encoding="utf-8") as f:
+        data = json.load(f)
+except (FileNotFoundError, json.JSONDecodeError):
+    data = {}
+
+if not isinstance(data, dict):
+    print("Error: labels.json must contain a JSON object at the top level.", file=sys.stderr)
+    sys.exit(1)
+
+try:
+    if value_type == "string":
+        value = raw_value
+
+    elif value_type == "number":
+        value = float(raw_value) if "." in raw_value else int(raw_value)
+
+    elif value_type == "boolean":
+        value = raw_value.lower() == "true"
+
+    elif value_type == "array_strings":
+        value = raw_value.split()
+        if not value:
+            raise ValueError("Array must contain at least one string.")
+
+    elif value_type == "array_numbers":
+        value = []
+        for item in raw_value.split():
+            value.append(float(item) if "." in item else int(item))
+        if not value:
+            raise ValueError("Array must contain at least one number.")
+
+    else:
+        raise ValueError("Unsupported value type.")
+
+except ValueError as exc:
+    print(f"Error: {exc}", file=sys.stderr)
+    sys.exit(1)
+
+data[key] = value
+
+with file_path.open("w", encoding="utf-8") as f:
+    json.dump(data, f, indent=4)
+    f.write("\n")
+
+print(f"Successfully added/updated key: {key}")
+PY
+}
+
+handle_add_label() {
+    local key=""
+    local type_choice=""
+    local value=""
+    local valid_array=true
+    local item=""
+
+    echo
+    key=$(read_non_empty "Enter the label key: ")
+    warn_if_no_domain_prefix "$key"
+
+    show_value_types
+    read -rp "Enter value type choice [1-5]: " type_choice
+
+    case "$type_choice" in
+        1)
+            value=$(read_non_empty "Enter string value: ")
+            add_to_json "$key" "string" "$value"
+            ;;
+
+        2)
+            while true; do
+                value=$(read_non_empty "Enter number value: ")
+                if validate_number "$value"; then
+                    break
+                fi
+                echo "Invalid number. Please enter a valid integer or decimal number."
+            done
+            add_to_json "$key" "number" "$value"
+            ;;
+
+        3)
+            while true; do
+                value=$(read_non_empty "Enter boolean value [true/false]: ")
+                if validate_boolean "$value"; then
+                    break
+                fi
+                echo "Invalid boolean. Please enter only true or false in lowercase."
+            done
+            add_to_json "$key" "boolean" "$value"
+            ;;
+
+        4)
+            value=$(read_non_empty "Enter array string values separated by spaces: ")
+            add_to_json "$key" "array_strings" "$value"
+            ;;
+
+        5)
+            while true; do
+                value=$(read_non_empty "Enter array number values separated by spaces: ")
+                valid_array=true
+
+                for item in $value; do
+                    if ! validate_number "$item"; then
+                        valid_array=false
+                        break
+                    fi
+                done
+
+                if [[ "$valid_array" == "true" ]]; then
+                    break
+                fi
+
+                echo "Invalid array. All values must be valid numbers."
+            done
+            add_to_json "$key" "array_numbers" "$value"
+            ;;
+
+        *)
+            echo "Invalid value type choice. Please select a number from 1 to 5."
+            return
+            ;;
+    esac
+
+    echo
+    echo "Current contents of $OUTPUT_FILE:"
+    python3 -m json.tool "$OUTPUT_FILE"
+}
+
+main() {
+    local choice=""
+
+    print_header
+    initialize_json_file
+
+    while true; do
+        show_main_menu
+        read -rp "Enter your choice [1-3]: " choice
+
+        case "$choice" in
+            1)
+                handle_add_label
+                ;;
+            2)
+                echo
+                echo "Current contents of $OUTPUT_FILE:"
+                python3 -m json.tool "$OUTPUT_FILE"
+                ;;
+            3)
+                echo
+                echo "Exiting. Final $OUTPUT_FILE:"
+                python3 -m json.tool "$OUTPUT_FILE"
+                echo
+                exit 0
+                ;;
+            *)
+                echo "Invalid choice. Please select 1, 2, or 3."
+                ;;
+        esac
+    done
+}
+
+main "$@"

--- a/scripts/device-agent.sh
+++ b/scripts/device-agent.sh
@@ -182,6 +182,7 @@ install_prerequisites() {
     sleep 5
     configure_coredns_hosts
   fi
+  update_capabilities_labels
 
   echo 'prerequisites installation completed.'
 }

--- a/scripts/modules/repositories.sh
+++ b/scripts/modules/repositories.sh
@@ -43,16 +43,18 @@ update_capabilities_labels() {
     local labels_file="./labels.json"
     local capabilities_file="$HOME/sandbox/poc/device/agent/config/capabilities.json"
 
-    # Check labels.json exists
+    # Check labels.json exists, if not, clean up the labels from configuration.json as well
     if [[ ! -f "$labels_file" ]]; then
         echo "File '$labels_file' not found, skipping label copying to capabilties"
+        remove_json_key $capabilities_file
         return 0
     fi
 
-    # Check labels.json is not empty
+    # Check labels.json is not empty, if not, clean up the labels from configuration.json as well
     if [[ ! -s "$labels_file" ]]; then
-        echo "File '$labels_file' is empty."
-        return 1
+        echo "File '$labels_file' is empty. skipping label copying to capabilties"
+        remove_json_key $capabilities_file
+        return 0
     fi
 
     # Validate JSON files
@@ -75,4 +77,26 @@ update_capabilities_labels() {
     && mv "$tmp_file" "$capabilities_file"
 
     echo "Successfully updated .labels in $capabilities_file"
+}
+
+# This will simply remove labels key from configuration.json
+remove_json_key() {
+    local file="$1"
+    local key="labels"
+
+    cp "$file" "$file.bak" || {
+        echo "ERROR: Failed to create backup of '$file'"
+        return 1
+    }
+
+    if jq "del(.${key})" "$file" > "$file.tmp" &&
+       mv "$file.tmp" "$file"; then
+        rm -f "$file.bak"
+        return 0
+    fi
+
+    echo "ERROR: Failed to remove key '${key}' from '$file'. Restoring original file."
+    mv "$file.bak" "$file" 2>/dev/null
+    rm -f "$file.tmp"
+    return 1
 }

--- a/scripts/modules/repositories.sh
+++ b/scripts/modules/repositories.sh
@@ -40,7 +40,7 @@ clone_dev_repo() {
 }
 
 update_capabilities_labels() {
-    local labels_file="./labels.json"
+    local labels_file="${SCRIPT_DIR}/labels.json"
     local capabilities_file="$HOME/sandbox/poc/device/agent/config/capabilities.json"
 
     # Check labels.json exists, if not, clean up the labels from configuration.json as well
@@ -100,3 +100,5 @@ remove_json_key() {
     rm -f "$file.tmp"
     return 1
 }
+
+WHITELIST: https://static.rust-lang.org , https://sh.rustup.rs

--- a/scripts/modules/repositories.sh
+++ b/scripts/modules/repositories.sh
@@ -38,3 +38,41 @@ clone_dev_repo() {
   cd "$HOME/sandbox"
   echo "✅ sandbox repo checkout to branch ${SANDBOX_REPO_BRANCH} done"
 }
+
+update_capabilities_labels() {
+    local labels_file="./labels.json"
+    local capabilities_file="$HOME/sandbox/poc/device/agent/config/capabilities.json"
+
+    # Check labels.json exists
+    if [[ ! -f "$labels_file" ]]; then
+        echo "File '$labels_file' not found, skipping label copying to capabilties"
+        return 0
+    fi
+
+    # Check labels.json is not empty
+    if [[ ! -s "$labels_file" ]]; then
+        echo "File '$labels_file' is empty."
+        return 1
+    fi
+
+    # Validate JSON files
+    jq empty "$labels_file" >/dev/null 2>&1 || {
+        echo "'$labels_file' contains invalid JSON."
+        return 1
+    }
+
+    jq empty "$capabilities_file" >/dev/null 2>&1 || {
+        echo "'$capabilities_file' contains invalid JSON."
+        return 1
+    }
+
+    # Replace .labels completely with contents of labels.json
+    tmp_file=$(mktemp)
+
+    jq --slurpfile labels "$labels_file" \
+       '.labels = $labels[0]' \
+       "$capabilities_file" > "$tmp_file" \
+    && mv "$tmp_file" "$capabilities_file"
+
+    echo "Successfully updated .labels in $capabilities_file"
+}

--- a/standard/generate.sh
+++ b/standard/generate.sh
@@ -6,7 +6,7 @@ export PATH="$PATH:$HOME/go/bin"
 #WFM_SBI_SPEC=("spec/wfm-sbi.yaml")
 
 TMP_SPEC="snapshot.spec.yaml"
-SPEC_URL="https://raw.githubusercontent.com/margo/specification/pre-draft/system-design/specification/margo-management-interface/workload-management-api-1.0.0-rc.2.yaml"
+SPEC_URL="https://raw.githubusercontent.com/margo/specification/pdp/custom-runtime-support-SUP/system-design/specification/margo-management-interface/workload-management-api-1.0.0-rc.2.yaml"
 curl -sSL -o "$TMP_SPEC" \
   "$SPEC_URL"
 WFM_SBI_SPEC="$TMP_SPEC"

--- a/standard/generatedCode/wfm/sbi/models.go
+++ b/standard/generatedCode/wfm/sbi/models.go
@@ -39,6 +39,33 @@ func (e ComponentStatusState) Valid() bool {
 	}
 }
 
+// Defines values for DeploymentCpuRequirementArchitectures.
+const (
+	DeploymentCpuRequirementArchitecturesAmd64   DeploymentCpuRequirementArchitectures = "amd64"
+	DeploymentCpuRequirementArchitecturesArm     DeploymentCpuRequirementArchitectures = "arm"
+	DeploymentCpuRequirementArchitecturesArm64   DeploymentCpuRequirementArchitectures = "arm64"
+	DeploymentCpuRequirementArchitecturesOther   DeploymentCpuRequirementArchitectures = "other"
+	DeploymentCpuRequirementArchitecturesRiscv64 DeploymentCpuRequirementArchitectures = "riscv64"
+)
+
+// Valid indicates whether the value is a known member of the DeploymentCpuRequirementArchitectures enum.
+func (e DeploymentCpuRequirementArchitectures) Valid() bool {
+	switch e {
+	case DeploymentCpuRequirementArchitecturesAmd64:
+		return true
+	case DeploymentCpuRequirementArchitecturesArm:
+		return true
+	case DeploymentCpuRequirementArchitecturesArm64:
+		return true
+	case DeploymentCpuRequirementArchitecturesOther:
+		return true
+	case DeploymentCpuRequirementArchitecturesRiscv64:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for DeploymentStatusManifestKind.
 const (
 	DeploymentStatusManifestKindDeploymentStatusManifest DeploymentStatusManifestKind = "DeploymentStatusManifest"
@@ -101,19 +128,19 @@ func (e DeviceCapabilitiesManifestKind) Valid() bool {
 
 // Defines values for DeviceCapabilitiesManifestPropertiesCpusArchitecture.
 const (
-	Amd64 DeviceCapabilitiesManifestPropertiesCpusArchitecture = "amd64"
-	Arm   DeviceCapabilitiesManifestPropertiesCpusArchitecture = "arm"
-	Arm64 DeviceCapabilitiesManifestPropertiesCpusArchitecture = "arm64"
+	DeviceCapabilitiesManifestPropertiesCpusArchitectureAmd64 DeviceCapabilitiesManifestPropertiesCpusArchitecture = "amd64"
+	DeviceCapabilitiesManifestPropertiesCpusArchitectureArm   DeviceCapabilitiesManifestPropertiesCpusArchitecture = "arm"
+	DeviceCapabilitiesManifestPropertiesCpusArchitectureArm64 DeviceCapabilitiesManifestPropertiesCpusArchitecture = "arm64"
 )
 
 // Valid indicates whether the value is a known member of the DeviceCapabilitiesManifestPropertiesCpusArchitecture enum.
 func (e DeviceCapabilitiesManifestPropertiesCpusArchitecture) Valid() bool {
 	switch e {
-	case Amd64:
+	case DeviceCapabilitiesManifestPropertiesCpusArchitectureAmd64:
 		return true
-	case Arm:
+	case DeviceCapabilitiesManifestPropertiesCpusArchitectureArm:
 		return true
-	case Arm64:
+	case DeviceCapabilitiesManifestPropertiesCpusArchitectureArm64:
 		return true
 	default:
 		return false
@@ -123,6 +150,7 @@ func (e DeviceCapabilitiesManifestPropertiesCpusArchitecture) Valid() bool {
 // Defines values for DeviceCapabilitiesManifestPropertiesSupportedDeploymentTypes.
 const (
 	DeviceCapabilitiesManifestPropertiesSupportedDeploymentTypesCompose DeviceCapabilitiesManifestPropertiesSupportedDeploymentTypes = "compose"
+	DeviceCapabilitiesManifestPropertiesSupportedDeploymentTypesCustom  DeviceCapabilitiesManifestPropertiesSupportedDeploymentTypes = "custom"
 	DeviceCapabilitiesManifestPropertiesSupportedDeploymentTypesHelm    DeviceCapabilitiesManifestPropertiesSupportedDeploymentTypes = "helm"
 )
 
@@ -130,6 +158,8 @@ const (
 func (e DeviceCapabilitiesManifestPropertiesSupportedDeploymentTypes) Valid() bool {
 	switch e {
 	case DeviceCapabilitiesManifestPropertiesSupportedDeploymentTypesCompose:
+		return true
+	case DeviceCapabilitiesManifestPropertiesSupportedDeploymentTypesCustom:
 		return true
 	case DeviceCapabilitiesManifestPropertiesSupportedDeploymentTypesHelm:
 		return true
@@ -140,13 +170,16 @@ func (e DeviceCapabilitiesManifestPropertiesSupportedDeploymentTypes) Valid() bo
 
 // Defines values for DeviceCapabilitiesManifestPropertiesSupportedRuntimes.
 const (
-	Oci DeviceCapabilitiesManifestPropertiesSupportedRuntimes = "oci"
+	DeviceCapabilitiesManifestPropertiesSupportedRuntimesCustom DeviceCapabilitiesManifestPropertiesSupportedRuntimes = "custom"
+	DeviceCapabilitiesManifestPropertiesSupportedRuntimesOci    DeviceCapabilitiesManifestPropertiesSupportedRuntimes = "oci"
 )
 
 // Valid indicates whether the value is a known member of the DeviceCapabilitiesManifestPropertiesSupportedRuntimes enum.
 func (e DeviceCapabilitiesManifestPropertiesSupportedRuntimes) Valid() bool {
 	switch e {
-	case Oci:
+	case DeviceCapabilitiesManifestPropertiesSupportedRuntimesCustom:
+		return true
+	case DeviceCapabilitiesManifestPropertiesSupportedRuntimesOci:
 		return true
 	default:
 		return false
@@ -213,6 +246,42 @@ func (e DevicePeripheralType) Valid() bool {
 	}
 }
 
+// Defines values for MatchExpressionOperator.
+const (
+	ContainsAll  MatchExpressionOperator = "ContainsAll"
+	ContainsAny  MatchExpressionOperator = "ContainsAny"
+	DoesNotExist MatchExpressionOperator = "DoesNotExist"
+	Exists       MatchExpressionOperator = "Exists"
+	Gt           MatchExpressionOperator = "Gt"
+	In           MatchExpressionOperator = "In"
+	Lt           MatchExpressionOperator = "Lt"
+	NotIn        MatchExpressionOperator = "NotIn"
+)
+
+// Valid indicates whether the value is a known member of the MatchExpressionOperator enum.
+func (e MatchExpressionOperator) Valid() bool {
+	switch e {
+	case ContainsAll:
+		return true
+	case ContainsAny:
+		return true
+	case DoesNotExist:
+		return true
+	case Exists:
+		return true
+	case Gt:
+		return true
+	case In:
+		return true
+	case Lt:
+		return true
+	case NotIn:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for AppDeploymentProfileType.
 const (
 	AppDeploymentProfileTypeCompose AppDeploymentProfileType = "compose"
@@ -246,6 +315,18 @@ func (e PostApiV1OnboardingJSONBodyKind) Valid() bool {
 	}
 }
 
+// CapacityRequirements Minimum device capacity required by the deployment profile.
+type CapacityRequirements struct {
+	// Cpu CPU element specifying the CPU requirements for the deployment.
+	Cpu *DeploymentCpuRequirement `json:"cpu,omitempty"`
+
+	// Memory The minimum amount of memory required. The value is given in binary units (`Ki` = Kibibytes, `Mi` = Mebibytes, `Gi` = Gibibytes).
+	Memory *string `json:"memory,omitempty"`
+
+	// Storage The minimum amount of storage required. The value is given in binary units (`Ki` = Kibibytes, `Mi` = Mebibytes, `Gi` = Gibibytes, `Ti` = Tebibytes, `Pi` = Pebibytes, `Ei` = Exbibytes).
+	Storage *string `json:"storage,omitempty"`
+}
+
 // ComponentStatus defines model for ComponentStatus.
 type ComponentStatus struct {
 	Error *struct {
@@ -274,6 +355,18 @@ type DeploymentBundleRef struct {
 	// Url Content-addressable retrieval endpoint of the form /api/v1/clients/{clientId}/bundles/{digest} where {digest} equals bundle.digest.
 	Url *string `json:"url,omitempty"`
 }
+
+// DeploymentCpuRequirement CPU element specifying the CPU requirements for the deployment.
+type DeploymentCpuRequirement struct {
+	// Architectures The CPU architectures supported by the deployment.
+	Architectures *[]DeploymentCpuRequirementArchitectures `json:"architectures,omitempty"`
+
+	// Cores The required amount of CPU cores. Specified as decimal units of CPU cores (e.g., `0.5` is half a core).
+	Cores float32 `json:"cores"`
+}
+
+// DeploymentCpuRequirementArchitectures defines model for DeploymentCpuRequirement.Architectures.
+type DeploymentCpuRequirementArchitectures string
 
 // DeploymentManifestRef Reference to a deployment manifest with content addressing and integrity verification.
 type DeploymentManifestRef struct {
@@ -317,6 +410,9 @@ type DeploymentStatusManifestStatusState string
 type DeviceCapabilitiesManifest struct {
 	ApiVersion string                         `json:"apiVersion"`
 	Kind       DeviceCapabilitiesManifestKind `json:"kind"`
+
+	// Labels Optional supplier-defined key/value pair metadata used for device matching via eligibilityRules label selectors. Values MUST be a string, number, boolean, or an array of strings or numbers. Margo does not assign semantics to any particular label key or value. Label keys are case-sensitive. Implementations SHOULD use stable, collision-resistant label names, prefixing with an organization domain is recommended.
+	Labels     *map[string]DeviceCapabilitiesManifest_Labels_AdditionalProperties `json:"labels,omitempty"`
 	Properties struct {
 		Cpus *[]struct {
 			Architecture *DeviceCapabilitiesManifestPropertiesCpusArchitecture `json:"architecture,omitempty"`
@@ -339,6 +435,26 @@ type DeviceCapabilitiesManifest struct {
 // DeviceCapabilitiesManifestKind defines model for DeviceCapabilitiesManifest.Kind.
 type DeviceCapabilitiesManifestKind string
 
+// DeviceCapabilitiesManifestLabels0 defines model for DeviceCapabilitiesManifest.Labels.0.
+type DeviceCapabilitiesManifestLabels0 = string
+
+// DeviceCapabilitiesManifestLabels1 defines model for DeviceCapabilitiesManifest.Labels.1.
+type DeviceCapabilitiesManifestLabels1 = float32
+
+// DeviceCapabilitiesManifestLabels2 defines model for DeviceCapabilitiesManifest.Labels.2.
+type DeviceCapabilitiesManifestLabels2 = bool
+
+// DeviceCapabilitiesManifestLabels3 defines model for DeviceCapabilitiesManifest.Labels.3.
+type DeviceCapabilitiesManifestLabels3 = []string
+
+// DeviceCapabilitiesManifestLabels4 defines model for DeviceCapabilitiesManifest.Labels.4.
+type DeviceCapabilitiesManifestLabels4 = []float32
+
+// DeviceCapabilitiesManifest_Labels_AdditionalProperties defines model for DeviceCapabilitiesManifest.labels.AdditionalProperties.
+type DeviceCapabilitiesManifest_Labels_AdditionalProperties struct {
+	union json.RawMessage
+}
+
 // DeviceCapabilitiesManifestPropertiesCpusArchitecture defines model for DeviceCapabilitiesManifest.Properties.Cpus.Architecture.
 type DeviceCapabilitiesManifestPropertiesCpusArchitecture string
 
@@ -356,6 +472,15 @@ type DeviceCommunicationInterface struct {
 // DeviceCommunicationInterfaceType defines model for DeviceCommunicationInterface.Type.
 type DeviceCommunicationInterfaceType string
 
+// DeviceConstraints Device constraints specifying the minimum device capabilities and eligibility rules required for the deployment.
+type DeviceConstraints struct {
+	// CapacityRequirements Minimum CPU, memory, and storage requirements for the deployment profile.
+	CapacityRequirements *CapacityRequirements `json:"capacityRequirements,omitempty"`
+
+	// EligibilityRules Optional rules used to match the deployment with device properties and supplier-defined labels reported in the device capabilities.
+	EligibilityRules *[]EligibilityRule `json:"eligibilityRules,omitempty"`
+}
+
 // DeviceId defines model for DeviceId.
 type DeviceId = string
 
@@ -372,8 +497,41 @@ type DevicePeripheral struct {
 // DevicePeripheralType defines model for DevicePeripheral.Type.
 type DevicePeripheralType string
 
+// EligibilityRule A rule matching properties and supplier-defined labels reported through the device capabilities.
+type EligibilityRule struct {
+	// LabelSelector Selector evaluated against the labels reported in the device capabilities.
+	LabelSelector *Selector `json:"labelSelector,omitempty"`
+
+	// PropertySelector Selector evaluated against the properties reported in the device capabilities.
+	PropertySelector *Selector `json:"propertySelector,omitempty"`
+}
+
 // ManifestVersion Monotonically increasing unsigned 64-bit integer in the inclusive range [1, 2^64-1]. Prevents rollback attacks. The first manifest MUST use 1.
 type ManifestVersion = float32
+
+// MatchExpression An expression used to match a device's reported capabilities properties or labels.
+type MatchExpression struct {
+	// ItemSelector A set of match expressions evaluated with AND semantics.
+	ItemSelector *Selector `json:"itemSelector,omitempty"`
+
+	// Key The key used to match the device's reported capabilities. For property selectors, this MUST be a JSON Pointer, as defined by RFC 6901, mapping to a specific property. For label selectors, this MUST be the exact label key.
+	Key string `json:"key"`
+
+	// Operator Operator used to evaluate the referenced value.
+	Operator MatchExpressionOperator `json:"operator"`
+
+	// Values Values used by the operator when required for matching expressions. Required for the `In`, `NotIn`, `Gt`, or `Lt` operator.
+	Values *[]interface{} `json:"values,omitempty"`
+}
+
+// MatchExpressionOperator Operator used to evaluate the referenced value.
+type MatchExpressionOperator string
+
+// Selector A set of match expressions evaluated with AND semantics.
+type Selector struct {
+	// MatchExpressions Match expressions evaluated against the device's reported capabilities.
+	MatchExpressions []MatchExpression `json:"matchExpressions"`
+}
 
 // UnsignedAppStateManifest defines model for UnsignedAppStateManifest.
 type UnsignedAppStateManifest struct {
@@ -425,6 +583,9 @@ type AppDeploymentParams map[string]AppParameterValue
 type AppDeploymentProfile struct {
 	// Components Components of the deployment profile
 	Components []AppDeploymentProfile_Components_Item `json:"components"`
+
+	// DeviceConstraints Device constraints specifying the minimum device capabilities and eligibility rules required for the deployment.
+	DeviceConstraints *DeviceConstraints `json:"deviceConstraints,omitempty"`
 
 	// Type Type of deployment profile
 	Type AppDeploymentProfileType `json:"type"`
@@ -556,6 +717,146 @@ type PostApiV1ClientsClientIdDeploymentsDeploymentIdStatusJSONRequestBody = Depl
 
 // PostApiV1OnboardingJSONRequestBody defines body for PostApiV1Onboarding for application/json ContentType.
 type PostApiV1OnboardingJSONRequestBody PostApiV1OnboardingJSONBody
+
+// AsDeviceCapabilitiesManifestLabels0 returns the union data inside the DeviceCapabilitiesManifest_Labels_AdditionalProperties as a DeviceCapabilitiesManifestLabels0
+func (t DeviceCapabilitiesManifest_Labels_AdditionalProperties) AsDeviceCapabilitiesManifestLabels0() (DeviceCapabilitiesManifestLabels0, error) {
+	var body DeviceCapabilitiesManifestLabels0
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromDeviceCapabilitiesManifestLabels0 overwrites any union data inside the DeviceCapabilitiesManifest_Labels_AdditionalProperties as the provided DeviceCapabilitiesManifestLabels0
+func (t *DeviceCapabilitiesManifest_Labels_AdditionalProperties) FromDeviceCapabilitiesManifestLabels0(v DeviceCapabilitiesManifestLabels0) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeDeviceCapabilitiesManifestLabels0 performs a merge with any union data inside the DeviceCapabilitiesManifest_Labels_AdditionalProperties, using the provided DeviceCapabilitiesManifestLabels0
+func (t *DeviceCapabilitiesManifest_Labels_AdditionalProperties) MergeDeviceCapabilitiesManifestLabels0(v DeviceCapabilitiesManifestLabels0) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+// AsDeviceCapabilitiesManifestLabels1 returns the union data inside the DeviceCapabilitiesManifest_Labels_AdditionalProperties as a DeviceCapabilitiesManifestLabels1
+func (t DeviceCapabilitiesManifest_Labels_AdditionalProperties) AsDeviceCapabilitiesManifestLabels1() (DeviceCapabilitiesManifestLabels1, error) {
+	var body DeviceCapabilitiesManifestLabels1
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromDeviceCapabilitiesManifestLabels1 overwrites any union data inside the DeviceCapabilitiesManifest_Labels_AdditionalProperties as the provided DeviceCapabilitiesManifestLabels1
+func (t *DeviceCapabilitiesManifest_Labels_AdditionalProperties) FromDeviceCapabilitiesManifestLabels1(v DeviceCapabilitiesManifestLabels1) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeDeviceCapabilitiesManifestLabels1 performs a merge with any union data inside the DeviceCapabilitiesManifest_Labels_AdditionalProperties, using the provided DeviceCapabilitiesManifestLabels1
+func (t *DeviceCapabilitiesManifest_Labels_AdditionalProperties) MergeDeviceCapabilitiesManifestLabels1(v DeviceCapabilitiesManifestLabels1) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+// AsDeviceCapabilitiesManifestLabels2 returns the union data inside the DeviceCapabilitiesManifest_Labels_AdditionalProperties as a DeviceCapabilitiesManifestLabels2
+func (t DeviceCapabilitiesManifest_Labels_AdditionalProperties) AsDeviceCapabilitiesManifestLabels2() (DeviceCapabilitiesManifestLabels2, error) {
+	var body DeviceCapabilitiesManifestLabels2
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromDeviceCapabilitiesManifestLabels2 overwrites any union data inside the DeviceCapabilitiesManifest_Labels_AdditionalProperties as the provided DeviceCapabilitiesManifestLabels2
+func (t *DeviceCapabilitiesManifest_Labels_AdditionalProperties) FromDeviceCapabilitiesManifestLabels2(v DeviceCapabilitiesManifestLabels2) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeDeviceCapabilitiesManifestLabels2 performs a merge with any union data inside the DeviceCapabilitiesManifest_Labels_AdditionalProperties, using the provided DeviceCapabilitiesManifestLabels2
+func (t *DeviceCapabilitiesManifest_Labels_AdditionalProperties) MergeDeviceCapabilitiesManifestLabels2(v DeviceCapabilitiesManifestLabels2) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+// AsDeviceCapabilitiesManifestLabels3 returns the union data inside the DeviceCapabilitiesManifest_Labels_AdditionalProperties as a DeviceCapabilitiesManifestLabels3
+func (t DeviceCapabilitiesManifest_Labels_AdditionalProperties) AsDeviceCapabilitiesManifestLabels3() (DeviceCapabilitiesManifestLabels3, error) {
+	var body DeviceCapabilitiesManifestLabels3
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromDeviceCapabilitiesManifestLabels3 overwrites any union data inside the DeviceCapabilitiesManifest_Labels_AdditionalProperties as the provided DeviceCapabilitiesManifestLabels3
+func (t *DeviceCapabilitiesManifest_Labels_AdditionalProperties) FromDeviceCapabilitiesManifestLabels3(v DeviceCapabilitiesManifestLabels3) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeDeviceCapabilitiesManifestLabels3 performs a merge with any union data inside the DeviceCapabilitiesManifest_Labels_AdditionalProperties, using the provided DeviceCapabilitiesManifestLabels3
+func (t *DeviceCapabilitiesManifest_Labels_AdditionalProperties) MergeDeviceCapabilitiesManifestLabels3(v DeviceCapabilitiesManifestLabels3) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+// AsDeviceCapabilitiesManifestLabels4 returns the union data inside the DeviceCapabilitiesManifest_Labels_AdditionalProperties as a DeviceCapabilitiesManifestLabels4
+func (t DeviceCapabilitiesManifest_Labels_AdditionalProperties) AsDeviceCapabilitiesManifestLabels4() (DeviceCapabilitiesManifestLabels4, error) {
+	var body DeviceCapabilitiesManifestLabels4
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromDeviceCapabilitiesManifestLabels4 overwrites any union data inside the DeviceCapabilitiesManifest_Labels_AdditionalProperties as the provided DeviceCapabilitiesManifestLabels4
+func (t *DeviceCapabilitiesManifest_Labels_AdditionalProperties) FromDeviceCapabilitiesManifestLabels4(v DeviceCapabilitiesManifestLabels4) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeDeviceCapabilitiesManifestLabels4 performs a merge with any union data inside the DeviceCapabilitiesManifest_Labels_AdditionalProperties, using the provided DeviceCapabilitiesManifestLabels4
+func (t *DeviceCapabilitiesManifest_Labels_AdditionalProperties) MergeDeviceCapabilitiesManifestLabels4(v DeviceCapabilitiesManifestLabels4) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+func (t DeviceCapabilitiesManifest_Labels_AdditionalProperties) MarshalJSON() ([]byte, error) {
+	b, err := t.union.MarshalJSON()
+	return b, err
+}
+
+func (t *DeviceCapabilitiesManifest_Labels_AdditionalProperties) UnmarshalJSON(b []byte) error {
+	err := t.union.UnmarshalJSON(b)
+	return err
+}
 
 // AsHelmApplicationDeploymentProfileComponent returns the union data inside the AppDeploymentProfile_Components_Item as a HelmApplicationDeploymentProfileComponent
 func (t AppDeploymentProfile_Components_Item) AsHelmApplicationDeploymentProfileComponent() (HelmApplicationDeploymentProfileComponent, error) {

--- a/standard/snapshot.spec.yaml
+++ b/standard/snapshot.spec.yaml
@@ -531,13 +531,32 @@ components:
               minItems: 1
               items:
                 type: string
-                enum: [oci]
+                enum: [oci, custom]
             supportedDeploymentTypes:
               type: array
               minItems: 1
               items:
                 type: string
-                enum: [helm, compose]
+                enum: [helm, compose, custom]
+        labels:
+          type: object
+          description: >-
+            Optional supplier-defined key/value pair metadata used for device matching via eligibilityRules
+            label selectors. Values MUST be a string, number, boolean, or an array of strings or numbers.
+            Margo does not assign semantics to any particular label key or value. Label keys are case-sensitive.
+            Implementations SHOULD use stable, collision-resistant label names, prefixing with an organization
+            domain is recommended.
+          additionalProperties:
+            oneOf:
+              - type: string
+              - type: number
+              - type: boolean
+              - type: array
+                items:
+                  type: string
+              - type: array
+                items:
+                  type: number
     DeviceId:
       # format: "{id}[/{id}[/{id}...]]"
       # Top-level id is required and must include only unreserved characters as specified in RFC3986.
@@ -748,6 +767,102 @@ components:
               - $ref: '#/components/schemas/helmApplicationDeploymentProfileComponent'
               - $ref: '#/components/schemas/composeApplicationDeploymentProfileComponent'
           description: Components of the deployment profile
+        deviceConstraints:
+          $ref: '#/components/schemas/DeviceConstraints'
+          description: Device constraints specifying the minimum device capabilities and eligibility rules required for the deployment.
+    DeviceConstraints:
+      type: object
+      description: >-
+        Device constraints specifying the minimum device capabilities and eligibility rules required for the deployment.
+      properties:
+        capacityRequirements:
+          $ref: '#/components/schemas/CapacityRequirements'
+          description: Minimum CPU, memory, and storage requirements for the deployment profile.
+        eligibilityRules:
+          type: array
+          items:
+            $ref: '#/components/schemas/EligibilityRule'
+          description: >-
+            Optional rules used to match the deployment with device properties and supplier-defined labels
+            reported in the device capabilities.
+    CapacityRequirements:
+      type: object
+      description: Minimum device capacity required by the deployment profile.
+      properties:
+        cpu:
+          $ref: '#/components/schemas/DeploymentCpuRequirement'
+          description: CPU element specifying the CPU requirements for the deployment.
+        memory:
+          type: string
+          description: >-
+            The minimum amount of memory required. The value is given in binary units
+            (`Ki` = Kibibytes, `Mi` = Mebibytes, `Gi` = Gibibytes).
+          pattern: ^[0-9]+(Mi|Gi|Ki)$
+        storage:
+          type: string
+          description: >-
+            The minimum amount of storage required. The value is given in binary units
+            (`Ki` = Kibibytes, `Mi` = Mebibytes, `Gi` = Gibibytes, `Ti` = Tebibytes, `Pi` = Pebibytes, `Ei` = Exbibytes).
+          pattern: ^[0-9]+(Mi|Gi|Ki|Ti|Pi|Ei)$
+    DeploymentCpuRequirement:
+      type: object
+      description: CPU element specifying the CPU requirements for the deployment.
+      required: [cores]
+      properties:
+        cores:
+          type: number
+          description: >-
+            The required amount of CPU cores. Specified as decimal units of CPU cores (e.g., `0.5` is half a core).
+        architectures:
+          type: array
+          items:
+            type: string
+            enum: [amd64, arm64, arm, riscv64, other]
+          description: The CPU architectures supported by the deployment.
+    EligibilityRule:
+      type: object
+      description: A rule matching properties and supplier-defined labels reported through the device capabilities.
+      properties:
+        propertySelector:
+          $ref: '#/components/schemas/Selector'
+          description: Selector evaluated against the properties reported in the device capabilities.
+        labelSelector:
+          $ref: '#/components/schemas/Selector'
+          description: Selector evaluated against the labels reported in the device capabilities.
+    Selector:
+      type: object
+      description: A set of match expressions evaluated with AND semantics.
+      required: [matchExpressions]
+      properties:
+        matchExpressions:
+          type: array
+          items:
+            $ref: '#/components/schemas/MatchExpression'
+          description: Match expressions evaluated against the device's reported capabilities.
+    MatchExpression:
+      type: object
+      description: An expression used to match a device's reported capabilities properties or labels.
+      required: [key, operator]
+      properties:
+        key:
+          type: string
+          description: >-
+            The key used to match the device's reported capabilities. For property selectors, this MUST be a JSON
+            Pointer, as defined by RFC 6901, mapping to a specific property. For label selectors, this MUST be the
+            exact label key.
+        operator:
+          type: string
+          enum: [In, NotIn, Exists, DoesNotExist, Gt, Lt, ContainsAll, ContainsAny]
+          description: Operator used to evaluate the referenced value.
+        values:
+          type: array
+          items: {}
+          description: >-
+            Values used by the operator when required for matching expressions. Required for the `In`, `NotIn`,
+            `Gt`, or `Lt` operator.
+        itemSelector:
+          $ref: '#/components/schemas/Selector'
+          description: Selector evaluated against array elements. Required for the `ContainsAll` or `ContainsAny` operator.
     appParameterTarget:
       type: object
       description: Application Parameter Target


### PR DESCRIPTION
This is an intermediate merge to add support of Labels in WFM Client. 
Summarized Changes: 

- Updated docs explaining how to add labels while installing a WFM Client.
- Added helper script for generating intermediate helper labels json file
- Updated scripts to automatically add labels in device configuration file
- Device Agent now reports labels as well, along with capabilities, to WFM. 