### PR TITLE
fix(cli): change the command for extracting the deployment type

### DIFF
--- a/scripts/easy-cli/cli-yaml-gen.sh
+++ b/scripts/easy-cli/cli-yaml-gen.sh
@@ -35,11 +35,7 @@ generate_instance_yaml_from_oci() {
   app_identifier=$(echo "$app_identifier" | cut -c1-40)
 
   # Determine deployment type
-  local deployment_type=$(awk '/deploymentProfile:/,/^[^ ]/ {if (/^\s+type:/) print}' margo.yaml | sed 's/.*type:\s*//' | tr -d '"' | tr -d "'" | xargs | head -1)
-
-  if [ -z "$deployment_type" ]; then
-    deployment_type=$(awk '/^spec:/,/^[^ ]/ {if (/^\s+type:/) print}' margo.yaml | sed 's/.*type:\s*//' | tr -d '"' | tr -d "'" | xargs | head -1)
-  fi
+  local deployment_type=$(awk '/deploymentProfiles:/,0 {if (/^\s*-\s*type:/) print}' margo.yaml | sed 's/.*type:\s*//' | tr -d '"' | tr -d "'" | xargs | head -1)
 
   if [ -z "$deployment_type" ]; then
     if [[ "$package_name" =~ compose ]]; then

--- a/scripts/easy-cli/cli-yaml-gen.sh
+++ b/scripts/easy-cli/cli-yaml-gen.sh
@@ -35,7 +35,7 @@ generate_instance_yaml_from_oci() {
   app_identifier=$(echo "$app_identifier" | cut -c1-40)
 
   # Determine deployment type
-  local deployment_type=$(awk '/deploymentProfiles:/,0 {if (/^\s*-\s*type:/) print}' margo.yaml | sed 's/.*type:\s*//' | tr -d '"' | tr -d "'" | xargs | head -1)
+  local deployment_type=$(awk '/deploymentProfiles:/,0 {if (/^[[:space:]]{2}-[[:space:]]*type:/) print}' margo.yaml | sed 's/.*type:[[:space:]]*//' | tr -d '"' | tr -d "'" | xargs | head -1)
 
   if [ -z "$deployment_type" ]; then
     if [[ "$package_name" =~ compose ]]; then


### PR DESCRIPTION
## Description

Fix deployment type detection in `scripts/easy-cli/cli-yaml-gen.sh`.

My deployment of a compose application was failed as the script couldn't extract the deployment type from the `margo.yaml`. The `spec` is no longer a top-level attribute, and `deploymentProfiles` (plural) is the correct field for deployment information. `deploymentProfiles` is also a list, so the existing `spec:`/`deploymentProfile:` parsing could not detect the deployment type.

## Motivation

Update the script to follow application description structure and correctly detect the deployment type.

## Testing

Tested with a simple `margo.org/v1-alpha1` Compose application description containing:

```console
azureuser@wfm:~/sandbox/poc/tests/artefacts/nextcloud-compose/margo-package$ deployment_type=$(awk '/deploymentProfile:/,/^[^ ]/ {if (/^\s+type:/) print}' margo.yaml | sed 's/.*type:\s*//' | tr -d '"' | tr -d "'" | xargs | head -1)
azureuser@wfm:~/sandbox/poc/tests/artefacts/nextcloud-compose/margo-package$ echo $deployment_type

azureuser@wfm:~/sandbox/poc/tests/artefacts/nextcloud-compose/margo-package$ deployment_type=$(awk '/deploymentProfiles:/,0 {if (/^\s*-\s*type:/) print}' margo.yaml | sed 's/.*type:\s*//' | tr -d '"' | tr -d "'" | xargs | head -1)
azureuser@wfm:~/sandbox/poc/tests/artefacts/nextcloud-compose/margo-package$ echo $deployment_type
compose
```

Result:

```text
Before fix: Detected deployment type:
After fix:  Detected deployment type: compose
```

## Checklist

* [ ] Tests added/updated
* [ ] Documentation updated
* [x] No breaking changes
* [x] Conventional commits used