### PR TITLE
Fix/deployment digest mismatch

### DIFF
--- a/poc/device/agent/stateSync.go
+++ b/poc/device/agent/stateSync.go
@@ -500,25 +500,25 @@ func (ss *StateSyncer) downloadAndExtractBundle(
 func (ss *StateSyncer) shouldDownloadBundle(
 	manifest *sbi.UnsignedAppStateManifest,
 ) bool {
-	// If no bundle available, must fetch individually
-	if manifest.Bundle == nil || manifest.Bundle.Digest == nil {
-		return false
-	}
+	// // If no bundle available, must fetch individually
+	// if manifest.Bundle == nil || manifest.Bundle.Digest == nil {
+	// 	return false
+	// }
 
-	// Heuristic: If more than 2 deployments, use bundle for efficiency
-	if len(manifest.Deployments) > 2 {
-		ss.log.Infow("Using bundle download (many deployments)",
-			"deploymentCount", len(manifest.Deployments))
-		return true
-	}
+	// // Heuristic: If more than 2 deployments, use bundle for efficiency
+	// if len(manifest.Deployments) > 2 {
+	// 	ss.log.Infow("Using bundle download (many deployments)",
+	// 		"deploymentCount", len(manifest.Deployments))
+	// 	return true
+	// }
 
-	// Heuristic: If bundle size is reasonable (< 50MB), use bundle
-	if manifest.Bundle.SizeBytes != nil &&
-		*manifest.Bundle.SizeBytes < 50*1024*1024 {
-		ss.log.Infow("Using bundle download (reasonable size)",
-			"sizeBytes", *manifest.Bundle.SizeBytes)
-		return true
-	}
+	// // Heuristic: If bundle size is reasonable (< 50MB), use bundle
+	// if manifest.Bundle.SizeBytes != nil &&
+	// 	*manifest.Bundle.SizeBytes < 50*1024*1024 {
+	// 	ss.log.Infow("Using bundle download (reasonable size)",
+	// 		"sizeBytes", *manifest.Bundle.SizeBytes)
+	// 	return true
+	// }
 
 	// Default: fetch individually for small number of deployments
 	ss.log.Infow("Using individual deployment fetch",

--- a/poc/device/agent/stateSync.go
+++ b/poc/device/agent/stateSync.go
@@ -504,7 +504,7 @@ func (ss *StateSyncer) shouldDownloadBundle(
 	if manifest.Bundle == nil || manifest.Bundle.Digest == nil {
 		return false
 	}
-
+    
 	// Heuristic: If more than 5 deployments, use bundle for efficiency
 	if len(manifest.Deployments) > 5 {
 		ss.log.Infow("Using bundle download (many deployments)",
@@ -512,7 +512,7 @@ func (ss *StateSyncer) shouldDownloadBundle(
 		return true
 	}
 
-	// Heuristic: If bundle size is reasonable (> 50MB), use bundle
+	// Heuristic: If bundle size is reasonable ( > 50MB), use bundle
 	if manifest.Bundle.SizeBytes != nil &&
 		*manifest.Bundle.SizeBytes > 50*1024*1024 {
 		ss.log.Infow("Using bundle download (reasonable size)",

--- a/poc/device/agent/stateSync.go
+++ b/poc/device/agent/stateSync.go
@@ -504,7 +504,7 @@ func (ss *StateSyncer) shouldDownloadBundle(
 	if manifest.Bundle == nil || manifest.Bundle.Digest == nil {
 		return false
 	}
-    
+
 	// Heuristic: If more than 5 deployments, use bundle for efficiency
 	if len(manifest.Deployments) > 5 {
 		ss.log.Infow("Using bundle download (many deployments)",

--- a/poc/device/agent/stateSync.go
+++ b/poc/device/agent/stateSync.go
@@ -500,25 +500,25 @@ func (ss *StateSyncer) downloadAndExtractBundle(
 func (ss *StateSyncer) shouldDownloadBundle(
 	manifest *sbi.UnsignedAppStateManifest,
 ) bool {
-	// // If no bundle available, must fetch individually
-	// if manifest.Bundle == nil || manifest.Bundle.Digest == nil {
-	// 	return false
-	// }
+	// If no bundle available, must fetch individually
+	if manifest.Bundle == nil || manifest.Bundle.Digest == nil {
+		return false
+	}
 
-	// // Heuristic: If more than 2 deployments, use bundle for efficiency
-	// if len(manifest.Deployments) > 2 {
-	// 	ss.log.Infow("Using bundle download (many deployments)",
-	// 		"deploymentCount", len(manifest.Deployments))
-	// 	return true
-	// }
+	// Heuristic: If more than 5 deployments, use bundle for efficiency
+	if len(manifest.Deployments) > 5 {
+		ss.log.Infow("Using bundle download (many deployments)",
+			"deploymentCount", len(manifest.Deployments))
+		return true
+	}
 
-	// // Heuristic: If bundle size is reasonable (< 50MB), use bundle
-	// if manifest.Bundle.SizeBytes != nil &&
-	// 	*manifest.Bundle.SizeBytes < 50*1024*1024 {
-	// 	ss.log.Infow("Using bundle download (reasonable size)",
-	// 		"sizeBytes", *manifest.Bundle.SizeBytes)
-	// 	return true
-	// }
+	// Heuristic: If bundle size is reasonable (> 50MB), use bundle
+	if manifest.Bundle.SizeBytes != nil &&
+		*manifest.Bundle.SizeBytes > 50*1024*1024 {
+		ss.log.Infow("Using bundle download (reasonable size)",
+			"sizeBytes", *manifest.Bundle.SizeBytes)
+		return true
+	}
 
 	// Default: fetch individually for small number of deployments
 	ss.log.Infow("Using individual deployment fetch",


### PR DESCRIPTION
Updates the optimization thresholds for bundle downloads:
1. Manifest deployment count trigger increased from >2 to >5.
2. Bundle size evaluation inverted to target payloads greater than 50MB (> 50MB) 