### PR TITLE
feat(scripts): assign spec-compliant Margo media types to application package resource files

### DIFF
--- a/scripts/modules/packages.sh
+++ b/scripts/modules/packages.sh
@@ -3,6 +3,60 @@
 
 source "$(dirname "${BASH_SOURCE[0]}")/../lib/common.sh"
 
+get_margo_media_type() {
+  local file="$1"
+  local filename
+  filename=$(basename "$file")
+  local ext="${filename##*.}"
+  ext=$(echo "$ext" | tr '[:upper:]' '[:lower:]')
+
+  local format="$ext"
+  case "$ext" in
+    md)       format="markdown" ;;
+    txt)      format="plain" ;;
+    jpg|jpeg) format="jpeg" ;;
+    png)      format="png" ;;
+    svg)      format="svg" ;;
+    pdf)      format="pdf" ;;
+    yaml|yml) format="yaml" ;;
+    json)     format="json" ;;
+  esac
+
+  # Match margo.yaml catalog references if yq is available
+  if command -v yq &>/dev/null && [ -f "margo.yaml" ]; then
+    local icon desc notes license
+    icon=$(yq eval '.metadata.catalog.application.icon // ""' margo.yaml 2>/dev/null)
+    desc=$(yq eval '.metadata.catalog.application.descriptionFile // ""' margo.yaml 2>/dev/null)
+    notes=$(yq eval '.metadata.catalog.application.releaseNotes // ""' margo.yaml 2>/dev/null)
+    license=$(yq eval '.metadata.catalog.application.licenseFile // ""' margo.yaml 2>/dev/null)
+
+    if [ "$file" = "$icon" ] || [ "./$file" = "$icon" ] || [ "$file" = "${icon#./}" ]; then
+      echo "application/vnd.margo.app.icon.v1+${format}"; return
+    elif [ "$file" = "$desc" ] || [ "./$file" = "$desc" ] || [ "$file" = "${desc#./}" ]; then
+      echo "application/vnd.margo.app.descriptionFile.v1+${format}"; return
+    elif [ "$file" = "$notes" ] || [ "./$file" = "$notes" ] || [ "$file" = "${notes#./}" ]; then
+      echo "application/vnd.margo.app.releaseNotes.v1+${format}"; return
+    elif [ "$file" = "$license" ] || [ "./$file" = "$license" ] || [ "$file" = "${license#./}" ]; then
+      echo "application/vnd.margo.app.licenseFile.v1+${format}"; return
+    fi
+  fi
+
+  # Fallback based on filename patterns
+  local lower_name
+  lower_name=$(echo "$filename" | tr '[:upper:]' '[:lower:]')
+  if [[ "$lower_name" =~ (icon|logo) ]]; then
+    echo "application/vnd.margo.app.icon.v1+${format}"
+  elif [[ "$lower_name" =~ (readme|description) ]]; then
+    echo "application/vnd.margo.app.descriptionFile.v1+${format}"
+  elif [[ "$lower_name" =~ (release_notes|releasenotes|changelog) ]]; then
+    echo "application/vnd.margo.app.releaseNotes.v1+${format}"
+  elif [[ "$lower_name" =~ (license|licence) ]]; then
+    echo "application/vnd.margo.app.licenseFile.v1+${format}"
+  else
+    echo "application/octet-stream"
+  fi
+}
+
 push_nextcloud_to_oci() {
   echo "📦 Pushing Nextcloud application package to OCI Registry (HTTPS)..."
 
@@ -33,7 +87,9 @@ push_nextcloud_to_oci() {
   if [ -d "resources" ] && [ "$(ls -A resources 2>/dev/null)" ]; then
     while IFS= read -r file; do
       if [ -f "$file" ]; then
-        files+=("$file:application/octet-stream")
+        local media_type
+        media_type=$(get_margo_media_type "$file")
+        files+=("$file:${media_type}")
       fi
     done < <(find resources -type f 2>/dev/null)
   fi
@@ -74,7 +130,9 @@ push_custom_otel_to_oci() {
   if [ -d "resources" ] && [ "$(ls -A resources 2>/dev/null)" ]; then
     while IFS= read -r file; do
       if [ -f "$file" ]; then
-        files+=("$file:application/octet-stream")
+        local media_type
+        media_type=$(get_margo_media_type "$file")
+        files+=("$file:${media_type}")
       fi
     done < <(find resources -type f 2>/dev/null)
   fi
@@ -122,7 +180,6 @@ build_custom_otel_container_images() {
 
   echo "Pushing chart to Harbor (HTTPS)..."
   helm push "custom-otel-helm-${CHART_VERSION}.tgz" "oci://${EXPOSED_HARBOR_HOST}:${EXPOSED_HARBOR_PORT}/library" 
-
 
   HELM_REPOSITORY="oci://${EXPOSED_HARBOR_HOST}:${EXPOSED_HARBOR_PORT}/library/custom-otel-helm"
   HELM_REVISION="$CHART_VERSION"

--- a/scripts/modules/packages.sh
+++ b/scripts/modules/packages.sh
@@ -48,7 +48,7 @@ get_margo_media_type() {
     echo "application/vnd.margo.app.icon.v1+${format}"
   elif [[ "$lower_name" =~ (readme|description) ]]; then
     echo "application/vnd.margo.app.descriptionFile.v1+${format}"
-  elif [[ "$lower_name" =~ (release_notes|releasenotes|changelog) ]]; then
+  elif [[ "$lower_name" =~ (release_notes|releasenotes|changelog|release-notes) ]]; then
     echo "application/vnd.margo.app.releaseNotes.v1+${format}"
   elif [[ "$lower_name" =~ (license|licence) ]]; then
     echo "application/vnd.margo.app.licenseFile.v1+${format}"


### PR DESCRIPTION
This PR updates the OCI packaging script (`scripts/modules/packages.sh`) to adhere to the [Margo Application Registry Specification](https://docs.margo.org/specification/applications/application-registry#margo-specific-media-types) when pushing application package resource files.

Previously, all resource files inside `resources/` were pushed as generic `application/octet-stream` layers. This update inspects `margo.yaml` (and falls back to file name conventions) to assign the appropriate Margo-specific media type and format suffix to each layer.

### Key Changes
1. **Added `get_margo_media_type` Helper**:
   - Matches referenced files under `metadata.catalog.application` in `margo.yaml` (`icon`, `descriptionFile`, `releaseNotes`, `licenseFile`).
   - Maps file extensions (`.md`, `.png`, `.jpg`, `.txt`, `.pdf`, etc.) to the required format suffixes (`+markdown`, `+png`, `+jpeg`, `+plain`, `+pdf`).
   - Dynamically constructs the layer media types:
     - `application/vnd.margo.app.icon.v1+{format}`
     - `application/vnd.margo.app.descriptionFile.v1+{format}`
     - `application/vnd.margo.app.releaseNotes.v1+{format}`
     - `application/vnd.margo.app.licenseFile.v1+{format}`
2. **Updated Package Push Functions**:
   - Replaced hardcoded `application/octet-stream` in `push_nextcloud_to_oci` and `push_custom_otel_to_oci` with dynamic media type resolution.
   
   
<img width="648" height="773" alt="image" src="https://github.com/user-attachments/assets/f9e3d39b-ff5e-4c13-a1ce-e4e2a5234d8d" />
